### PR TITLE
Add support for doorkeeper 5.6.0.rc1

### DIFF
--- a/doorkeeper-openid_connect.gemspec
+++ b/doorkeeper-openid_connect.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.5'
 
-  spec.add_runtime_dependency 'doorkeeper', '>= 5.5', '< 5.6'
+  spec.add_runtime_dependency 'doorkeeper', '>= 5.5', '< 5.7'
   spec.add_runtime_dependency 'json-jwt', '>= 1.11.0'
 
   spec.add_development_dependency 'conventional-changelog', '~> 1.2'

--- a/lib/doorkeeper/openid_connect/orm/active_record.rb
+++ b/lib/doorkeeper/openid_connect/orm/active_record.rb
@@ -4,13 +4,28 @@ require 'active_support/lazy_load_hooks'
 
 module Doorkeeper
   module OpenidConnect
+    autoload :AccessGrant, "doorkeeper/openid_connect/orm/active_record/access_grant"
+    autoload :Request, "doorkeeper/openid_connect/orm/active_record/request"
+    
     module Orm
       module ActiveRecord
+        def run_hooks
+          super
+          Doorkeeper::AccessGrant.prepend Doorkeeper::OpenidConnect::AccessGrant
+          if Doorkeeper.configuration.active_record_options[:establish_connection]
+            [Doorkeeper::OpenidConnect::Request].each do |c|
+              c.send :establish_connection, Doorkeeper.configuration.active_record_options[:establish_connection]
+            end
+          end
+        end
+
         def initialize_models!
           super
           ActiveSupport.on_load(:active_record) do
             require 'doorkeeper/openid_connect/orm/active_record/access_grant'
             require 'doorkeeper/openid_connect/orm/active_record/request'
+
+            Doorkeeper::AccessGrant.prepend Doorkeeper::OpenidConnect::AccessGrant
 
             if Doorkeeper.configuration.active_record_options[:establish_connection]
               [Doorkeeper::OpenidConnect::Request].each do |c|

--- a/lib/doorkeeper/openid_connect/orm/active_record/access_grant.rb
+++ b/lib/doorkeeper/openid_connect/orm/active_record/access_grant.rb
@@ -13,6 +13,4 @@ module Doorkeeper
       end
     end
   end
-
-  AccessGrant.prepend OpenidConnect::AccessGrant
 end

--- a/spec/models/access_grant_spec.rb
+++ b/spec/models/access_grant_spec.rb
@@ -15,6 +15,10 @@ describe Doorkeeper::OpenidConnect::AccessGrant do
     })
   end
 
+  it 'extends the base doorkeeper AccessGrant' do
+    expect(subject).to respond_to(:"openid_request=")
+  end
+
   describe '#delete' do
     it 'cascades to oauth_openid_requests' do
       if Rails::VERSION::MAJOR >= 6


### PR DESCRIPTION
Doorkeeper 5.6.0.rc1 changes how the autoloading works for orms. This patch autoloads its extensions using the built-in autoloader. When used with older doorkeeper versions, the  `initialize_models!` call should continue to work.